### PR TITLE
Calculate test accuracy and fix a couple of minor issues.

### DIFF
--- a/P2-Traffic-Sign-Detection/Solution-2FC.ipynb
+++ b/P2-Traffic-Sign-Detection/Solution-2FC.ipynb
@@ -245,12 +245,12 @@
     "    sess = tf.get_default_session()\n",
     "    acc_steps = len(X_data) // BATCH_SIZE\n",
     "    for i in range(acc_steps):\n",
-    "        batch_x, batch_y = next_batch(X_val, Y_val, BATCH_SIZE)\n",
+    "        batch_x, batch_y = next_batch(X_data, y_data, BATCH_SIZE)\n",
     "                   \n",
     "        loss, accuracy = sess.run([loss_value, acc], feed_dict={\n",
     "                images_placeholder: batch_x,\n",
     "                labels_placeholder: batch_y,\n",
-    "                keep_prob: 0.5\n",
+    "                keep_prob: 1.\n",
     "                })\n",
     "        total_accuracy += (accuracy * len(batch_x))\n",
     "        total_loss += (loss * len(batch_x))\n",
@@ -913,7 +913,7 @@
      "output_type": "stream",
      "text": [
       "Model restored.\n",
-      "Test Accuracy = 99.018\n"
+      "Test Accuracy = 95.534\n"
      ]
     }
    ],
@@ -921,7 +921,7 @@
     "with tf.Session() as sess:\n",
     "    saver.restore(sess, '/home/ubuntu/gtsd-199.chkpt')\n",
     "    print(\"Model restored.\")\n",
-    "    test_accuracy = evaluate(X_test, y_test)\n",
+    "    test_accuracy = evaluate(X_test, Y_test)\n",
     "    print(\"Test Accuracy = {:.3f}\".format(test_accuracy[0]*100))"
    ]
   },

--- a/P2-Traffic-Sign-Detection/Solution-2FC.ipynb
+++ b/P2-Traffic-Sign-Detection/Solution-2FC.ipynb
@@ -206,11 +206,13 @@
     "# calculate loss\n",
     "loss_value = loss(logits, labels_placeholder)\n",
     "\n",
+    "predictions = tf.nn.softmax(logits)\n",
+    "\n",
     "# training\n",
     "train_op = training(loss_value, 0.0001)\n",
     "\n",
     "# accuracy\n",
-    "acc = accuracy(logits, labels_placeholder)\n",
+    "acc = accuracy(predictions, labels_placeholder)\n",
     "\n",
     "saver = tf.train.Saver()"
    ]


### PR DESCRIPTION
Hi @autojazari, I did run your code quickly and found that you do indeed have a couple of bugs here: 

- `keep_prob = 0.5` is used while evaluation, e.g. dropout is not switched off when testing. 
- Softmax is not applied to logits when getting predictions. 
- Last and most importantly, when evaluating test set actually accuracy on the validation set is calculated — check out the `evaluate()` method.